### PR TITLE
PHPUnit\Framework\TestCase ao invés de PHPUnit_Framework_TestCase

### DIFF
--- a/tests/Connectors/BufferTest.php
+++ b/tests/Connectors/BufferTest.php
@@ -9,8 +9,9 @@ namespace Posprint\Tests\Connectors;
  */
 
 use Posprint\Connectors\Buffer;
+use PHPUnit\Framework\TestCase;
 
-class BufferTest extends \PHPUnit_Framework_TestCase
+class BufferTest extends TestCase
 {
     /**
      * @covers Posprint\Connectors\Buffer::__construct

--- a/tests/Connectors/FileTest.php
+++ b/tests/Connectors/FileTest.php
@@ -9,8 +9,9 @@ namespace Posprint\Tests\Connectors;
  */
 
 use Posprint\Connectors\File;
+use PHPUnit\Framework\TestCase;
 
-class FileTest extends \PHPUnit_Framework_TestCase
+class FileTest extends TestCase
 {
     public function testInstantiable()
     {

--- a/tests/Connectors/NetworkTest.php
+++ b/tests/Connectors/NetworkTest.php
@@ -9,8 +9,9 @@ namespace Posprint\Tests\Connectors;
  */
 
 use Posprint\Connectors\Network;
+use PHPUnit\Framework\TestCase;
 
-class NetworkTest extends \PHPUnit_Framework_TestCase
+class NetworkTest extends TestCase
 {
     /**
      * @expectedException RuntimeException

--- a/tests/Extras/PhpSerialTest.php
+++ b/tests/Extras/PhpSerialTest.php
@@ -8,8 +8,9 @@ namespace Posprint\Tests\Extras;
  */
 
 use Posprint\Extras\PhpSerial;
+use PHPUnit\Framework\TestCase;
 
-class PhpSerialTest extends \PHPUnit_Framework_TestCase
+class PhpSerialTest extends TestCase
 {
     public function testInstantiable()
     {

--- a/tests/Graphics/GraphicsTest.php
+++ b/tests/Graphics/GraphicsTest.php
@@ -9,8 +9,9 @@ namespace Posprint\Tests\Graphics;
  */
 
 use Posprint\Graphics\Graphics;
+use PHPUnit\Framework\TestCase;
 
-class GraphicsTest extends \PHPUnit_Framework_TestCase
+class GraphicsTest extends TestCase
 {
     
     public function testInstantiable()

--- a/tests/Printers/BematechTest.php
+++ b/tests/Printers/BematechTest.php
@@ -9,8 +9,9 @@ namespace Posprint\Tests\Printers;
  */
 
 use Posprint\Printers\Bematech;
+use PHPUnit\Framework\TestCase;
 
-class BematechTest extends \PHPUnit_Framework_TestCase
+class BematechTest extends TestCase
 {
     public function testInitialize()
     {

--- a/tests/Printers/DarumaTest.php
+++ b/tests/Printers/DarumaTest.php
@@ -9,8 +9,9 @@ namespace Posprint\Tests\Printers;
  */
 
 use Posprint\Printers\Daruma;
+use PHPUnit\Framework\TestCase;
 
-class DarumaTest extends \PHPUnit_Framework_TestCase
+class DarumaTest extends TestCase
 {
     public function testInitialize()
     {

--- a/tests/Printers/DieboldTest.php
+++ b/tests/Printers/DieboldTest.php
@@ -9,8 +9,9 @@ namespace Posprint\Tests\Printers;
  */
 
 use Posprint\Printers\Diebold;
+use PHPUnit\Framework\TestCase;
 
-class DieboldTest extends \PHPUnit_Framework_TestCase
+class DieboldTest extends TestCase
 {
     public function testInitialize()
     {

--- a/tests/Printers/ElginTest.php
+++ b/tests/Printers/ElginTest.php
@@ -9,8 +9,9 @@ namespace Posprint\Tests\Printers;
  */
 
 use Posprint\Printers\Elgin;
+use PHPUnit\Framework\TestCase;
 
-class ElginTest extends \PHPUnit_Framework_TestCase
+class ElginTest extends TestCase
 {
     public function testInitialize()
     {

--- a/tests/Printers/EpsonTest.php
+++ b/tests/Printers/EpsonTest.php
@@ -9,8 +9,9 @@ namespace Posprint\Tests\Printers;
  */
 
 use Posprint\Printers\Epson;
+use PHPUnit\Framework\TestCase;
 
-class EpsonTest extends \PHPUnit_Framework_TestCase
+class EpsonTest extends TestCase
 {
     public function testInstantiable()
     {

--- a/tests/Printers/StarTest.php
+++ b/tests/Printers/StarTest.php
@@ -9,8 +9,9 @@ namespace Posprint\Tests\Printers;
  */
 
 use Posprint\Printers\Star;
+use PHPUnit\Framework\TestCase;
 
-class StarTest extends \PHPUnit_Framework_TestCase
+class StarTest extends TestCase
 {
     public function testInitialize()
     {

--- a/tests/Printers/SwedaTest.php
+++ b/tests/Printers/SwedaTest.php
@@ -9,8 +9,9 @@ namespace Posprint\Tests\Printers;
  */
 
 use Posprint\Printers\Sweda;
+use PHPUnit\Framework\TestCase;
 
-class SwedaTest extends \PHPUnit_Framework_TestCase
+class SwedaTest extends TestCase
 {
     public function testInitialize()
     {


### PR DESCRIPTION
Usei `PHPUnit\Framework\TestCase` ao invés de `PHPUnit_Framework_TestCase` enquanto extendendo a classe `PHPUnit TestCase`. Isso irá nos ajudar quando migrarmos para o `PHPUnit 6`, que [não mais suporta _snake case namespaces_](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).