### PR TITLE
Garantir que tPag seja uma string

### DIFF
--- a/src/DanfcePos.php
+++ b/src/DanfcePos.php
@@ -234,7 +234,7 @@ class DanfcePos
         $pag = $this->nfce->infNFe->pag;
         $tot = $pag->count();
         for ($x=0; $x<=$tot-1; $x++) {
-            $tPag = $this->tipoPag($pag[0]->tPag);
+            $tPag = (string) $this->tipoPag((string) $pag[0]->tPag);
             $vPag = (float) $pag[0]->vPag;
             $this->printer->text($tPag . '                  R$ '. $vPag);
         }


### PR DESCRIPTION
Para evitar a exceção "array_key_exists(): The first argument should be either a string or an integer", tPag convertido para string antes de ser usado como index no array de formas de pagamento da função tipoPag.